### PR TITLE
GoToPercent uses number of pages if available.

### DIFF
--- a/Reader/FB3Reader.js
+++ b/Reader/FB3Reader.js
@@ -388,9 +388,27 @@ var FB3Reader;
             }
         };
 
+        /**
+        * Navigates to the specific percentage taking into account current cache
+        * status, namely whether we already know total number of pages or not.
+        * If not, block-wise navigation will be used instead of a page-wise.
+        *
+        * @param Percent The target percentage to navigate to.
+        */
         Reader.prototype.GoToPercent = function (Percent) {
-            var BlockN = Math.round(this.FB3DOM.TOC[this.FB3DOM.TOC.length - 1].e * Percent / 100);
-            this.GoTO([BlockN]);
+            if (this.IsFullyInCache()) {
+                var totalPages = this.PagesPositionsCache.Length();
+                var newPage = Math.round(totalPages * Percent / 100);
+                if (newPage < 0) {
+                    newPage = 0;
+                } else if (newPage >= totalPages) {
+                    newPage = totalPages - 1; // If there are 233 pages, then the last available one is 232.
+                }
+                this.GoTOPage(newPage);
+            } else {
+                var BlockN = Math.round(this.FB3DOM.TOC[this.FB3DOM.TOC.length - 1].e * Percent / 100);
+                this.GoTO([BlockN]);
+            }
         };
 
         Reader.prototype.CurPosPercent = function () {
@@ -428,7 +446,7 @@ var FB3Reader;
                     case 'load_page':
                         var PageToPrerender = this.FirstUncashedPage();
                         var NewPos = PageToPrerender.Start[0] / this.FB3DOM.TOC[this.FB3DOM.TOC.length - 1].e * 100;
-                        if (this.FB3DOM.TOC[this.FB3DOM.TOC.length - 1].e <= PageToPrerender.Start[0]) {
+                        if (this.IsFullyInCache()) {
                             // Caching done - we save results and stop idle processing
                             this.PagesPositionsCache.LastPage(this.PagesPositionsCache.Length() - 1);
                             this.IdleOff();
@@ -478,6 +496,15 @@ var FB3Reader;
                     default:
                 }
             }
+        };
+
+        /**
+        * Returns a value indicating whether book's content has
+        * already been fully loaded into cache or not.
+        */
+        Reader.prototype.IsFullyInCache = function () {
+            var pageToPrerender = this.FirstUncashedPage();
+            return this.FB3DOM.TOC[this.FB3DOM.TOC.length - 1].e <= pageToPrerender.Start[0];
         };
 
         Reader.prototype.SaveCache = function () {


### PR DESCRIPTION
- GoToPercent now checks the cache status. If everything is preloaded - it
  uses total number of page to calculate the target page.
- JSDoc comments are added to new\modified methods (they are shown in intellisence tooltips in VS2013).
